### PR TITLE
Fixed : piwikPlugin disallow direct request from other plugin

### DIFF
--- a/PiwikPlugin/PiwikPlugin.php
+++ b/PiwikPlugin/PiwikPlugin.php
@@ -206,12 +206,15 @@ class PiwikPlugin extends PluginBase {
 		$oRequest=$this->pluginManager->getAPI()->getRequest();
 		$sController=Yii::app()->getUrlManager()->parseUrl($oRequest);
 		$sAction=$this->getParam('action');
-		$bAdminPage= substr($sController, 0, 5)=='admin' || $sAction=='previewgroup' || $sAction=='previewquestion';// What for plugins ?
+		if ($sController=='upload/index');// Uploader return message broken : TODO test param('mode')
+			return;
 
-		if ( !$bAdminPage || $this->get('piwik_trackAdminPages', null, null, false))
-		{
-			$this->loadPiwikTrackingCode();
-		}
+		$bAdminPage= substr($sController, 0, 5)=='admin' || $sAction=='previewgroup' || $sAction=='previewquestion';// What for plugins ?
+		if ($bAdminPage && !$this->get('piwik_trackAdminPages', null, null, false) ) // Is an admin page
+			return;
+
+		$this->loadPiwikTrackingCode();
+
 	}
 
 	public function beforeSurveyPage(){
@@ -337,6 +340,7 @@ class PiwikPlugin extends PluginBase {
 	/******* Page Tracking functions ********/
 
 	function setCustomURL($aUrlInfo){
+
 		if ($piwik_rewriteURLs=$this->get('piwik_rewriteURLs', null, null, $this->settings['piwik_rewriteURLs']['default']))
 		{
 			//Write the custom URL to the piwikForLimeSurvey JS variable. This is then read inside loadPiwikTrackingCode()
@@ -371,7 +375,6 @@ class PiwikPlugin extends PluginBase {
 					break;
 			}
 			$piwikCustomUrl="_paq.push(['setCustomUrl', '$sCustomUrl']);\n";
-			tracevar($sCustomUrl);
 			App()->getClientScript()->registerScript('piwikCustomUrlVariable',$piwikCustomUrl,CClientScript::POS_BEGIN); 
 		}
 	}
@@ -559,7 +562,7 @@ $('#movenextbtn').on('click',function(){_paq.push(['trackEvent', '$eventCategory
 	public function newDirectRequest(){
 		//Handles additional plugin pages, used to display
 		$event = $this->event;
-		if ($event->get('target') != get_class())
+		if ($event->get('target') != get_class()) // Do it only for THIS plugin
 			return;
 		$request = $event->get('request');
 		$functionToCall = $event->get('function');

--- a/PiwikPlugin/PiwikPlugin.php
+++ b/PiwikPlugin/PiwikPlugin.php
@@ -559,6 +559,8 @@ $('#movenextbtn').on('click',function(){_paq.push(['trackEvent', '$eventCategory
 	public function newDirectRequest(){
 		//Handles additional plugin pages, used to display
 		$event = $this->event;
+		if ($event->get('target') != get_class())
+			return;
 		$request = $event->get('request');
 		$functionToCall = $event->get('function');
 		$content = call_user_func(array($this,$functionToCall));

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This is currently *alpha* software. It's progressing rapidly, and will be Beta s
  ```
  git clone https://github.com/SteveCohen/Piwik-for-Limesurvey.git PiwikPlugin
  ```
-
  
 2. Use Limesurvey's 'Plugin Manager' to specify at least the Piwik URL and SiteID
 3. Test that it's working for you. 
@@ -32,7 +31,7 @@ Please do submit an issue if you have anything to add: Feedback, commits and cri
 		- [x] Survey resumption
 	- And consider others like...
 		- [ ] Survey starts (hits to welcome page)
-	- [ ] Allow event tracking to be enabled/disabled per-survey
+	- [x] Allow event tracking to be enabled/disabled per-survey
 - [x] Uses Piwik content tracking to track which questions have actually been displayed to respondents
 	- [x] Track interactions with response options (e.g. track whether some questions are changed more than others)
 	- [ ] Allow content tracking to be enabled/disabled per-survey
@@ -76,8 +75,12 @@ Limesurvey doesn't always use the most informative URLs. For example, if you loo
 ``` 
 /index.php/survey/index
 ```
-This feature rewrites the URLs to add information to the URL, and goes to an existing page according to parameters.
 
+This feature rewrites the URLs to add information to the URL, and goes to an existing page according to parameters.
+* Disabled : use the real link shown to the user
+* Unreal link : Start by survey id, follow by gid, qid , event (save,load ..)
+* Admin link : To the survey view, group view or question view, with more information
+* Public link : To start of the survey with more information
 
 ## Content Tracking: Track respondents' interactions with answer options
 Options: Enabled / Disabled


### PR DESCRIPTION
* Fixed : piwikPlugin disallow direct request from other plugin
** Without this fix : all other Plugin can not use newDirectRequest event
* Fixed : upload question type broken
** The uploader controller return message directly like txt, adding <javascript> broke the upload question type