### PR TITLE
Deactivate call for command action

### DIFF
--- a/PiwikPlugin/PiwikPlugin.php
+++ b/PiwikPlugin/PiwikPlugin.php
@@ -105,7 +105,7 @@ class PiwikPlugin extends PluginBase {
 	);
 	/**
 	* track if javascript is done
-	* @var boolean 
+	* @var boolean
 	*/
 	private $registeredTrackingCode;
 	/**
@@ -200,23 +200,27 @@ class PiwikPlugin extends PluginBase {
 		}
 	}
 
+	/**
+	 * Load the picik tracking code
+	 * @todo : move it to new event beforeControllerAction
+	 */
 	public function afterPluginLoad(){
+		if(Yii::app() instanceof CConsoleApplication)
+			return;
 		/* Find the active controller with Yii parseUrl */
 		/* Remove for admin controller, review for plugins/direct */
-
 		$oRequest=$this->pluginManager->getAPI()->getRequest();
 		$sController=Yii::app()->getUrlManager()->parseUrl($oRequest);
 		$sAction=$this->getParam('action');
 
-		if ($sController=='upload/index')// Uploader return message broken : TODO test param('mode')
+		if ($sController=='upload/index')// Uploader return message broken : see @todo
 			return;
 
-		$bAdminPage= substr($sController, 0, 5)=='admin' || $sAction=='previewgroup' || $sAction=='previewquestion';// What for plugins ?
+		$bAdminPage= substr($sController, 0, 5)=='admin' || $sAction=='previewgroup' || $sAction=='previewquestion';// What for plugins, see @todo
 		if ($bAdminPage && !$this->get('piwik_trackAdminPages', null, null, false) ) // Is an admin page
 			return;
 
 		$this->loadPiwikTrackingCode();
-
 	}
 
 	public function beforeSurveyPage(){
@@ -297,6 +301,7 @@ class PiwikPlugin extends PluginBase {
 	function loadPiwikTrackingCode(){
 		$piwikID=trim($this->get('piwik_siteID', null, null, false));
 		$piwikURL=trim($this->get('piwik_piwikURL', null, null, false));
+
 		//For comment: Could check if the last character is a slash to ensure it's a directory.
 		if (substr($piwikURL,-1)<>"/"){ $piwikURL=""; }
 
@@ -341,7 +346,6 @@ class PiwikPlugin extends PluginBase {
 	/******* Page Tracking functions ********/
 
 	function setCustomURL($aUrlInfo){
-
 		if ($piwik_rewriteURLs=$this->get('piwik_rewriteURLs', null, null, $this->settings['piwik_rewriteURLs']['default']))
 		{
 			//Write the custom URL to the piwikForLimeSurvey JS variable. This is then read inside loadPiwikTrackingCode()
@@ -376,7 +380,7 @@ class PiwikPlugin extends PluginBase {
 					break;
 			}
 			$piwikCustomUrl="_paq.push(['setCustomUrl', '$sCustomUrl']);\n";
-			App()->getClientScript()->registerScript('piwikCustomUrlVariable',$piwikCustomUrl,CClientScript::POS_BEGIN); 
+			App()->getClientScript()->registerScript('piwikCustomUrlVariable',$piwikCustomUrl,CClientScript::POS_BEGIN);
 		}
 	}
 
@@ -563,7 +567,7 @@ $('#movenextbtn').on('click',function(){_paq.push(['trackEvent', '$eventCategory
 	public function newDirectRequest(){
 		//Handles additional plugin pages, used to display
 		$event = $this->event;
-		if ($event->get('target') != get_class()) // Do it only for THIS plugin
+		if ($event->get('target') != get_class())
 			return;
 		$request = $event->get('request');
 		$functionToCall = $event->get('function');

--- a/changelog.md
+++ b/changelog.md
@@ -6,35 +6,39 @@
  - Better phrasing of setting labels.
  - Add plugin settings to allow tracking to be disabled/enabled on Admin pages or all Survey pages. This requires a weird use of beforeSurveyPage() and afterPluginLoad().
  - WARNING: Code allowing per-survey tracking is incomplete. This doesn't yet retrieve per-survey settings. Still trying to work out how to do this.
- 
+
 4 Feb 2015
  - Enabled per-survey tracking options (thank you, Denis Chenu!)
- - Enabled tracking on survey listing page 
+ - Enabled tracking on survey listing page
 
 10 Feb 2015
  - Rewrite uninformative Limesurvey URLs to provide additional information within Piwik. e.g. groupID/questionID now appear in URLs. (Note this means the actual URL does not match that in Piwik, but they are nearly the same) - thanks @Shnoulle
  - Added event tracking (use of back/forward/save/clear buttons) and content tracking (impression and interaction with questions)
- 
+
 14 Feb 2015
  - Adds new JS event tracking function (and PHP placeholder)
  - Fix event tracking for clear/loaded survey (added javascript to the pages, not just the buttons)
- - Allow URL rewriting to be disabled (inefficient code but functional) 
- - Code spacing and formatting tidyup. 
- 
+ - Allow URL rewriting to be disabled (inefficient code but functional)
+ - Code spacing and formatting tidyup.
+
 15 Feb 2015
  - Content tracking now works correctly: interactions with any response option for a given question (or subquestion) are now tracked.
  - Custom URL set initially in the JS piwikForLimeSurvey array, and later read into the _paq (also using Javascript) - per solution suggested in [issue #7](https://github.com/SteveCohen/Piwik-for-Limesurvey/issues/7)
  - Fixed bug where URLs were tracked twice per hit
- 
+
  28 Feb 2015
  - Reorder code to group similar functions
  - Use _paq instead of custom JS variables as discussed further in [issue #7](https://github.com/SteveCohen/Piwik-for-Limesurvey/issues/7)
  - Added documentation to readme
  - Started newDirectRequest page/placeholder to embed stats and help inside LimeSurvey
  - Hid 'piwik_saveResponseIDtoPiwik' settings until it actually works
- 
+
  10 march 2015
  - New setting for rewriting url : rewrite to existing public page or existing admin pages
  - Fix event : for all template and set only for needed input
  - Add lang at end of the url
+
+ 27 may 2016
+ - Fix : don't try to be loaded if we are in console
+
 


### PR DESCRIPTION
With piwik plugin : we are unable to use cron event.

PS : tell me when you start 2.50 compatibility : we can better load this plugin with beforeControllerAction : even for "survey list" or upload files , or plugin direct request too :)