### PR TITLE
LimeSurvey 3 compatibility

### DIFF
--- a/PiwikPlugin/PiwikPlugin.php
+++ b/PiwikPlugin/PiwikPlugin.php
@@ -20,6 +20,9 @@
  * GNU General Public License for more details.
  *
  */
+
+use LimeSurvey\PluginManager\PluginManager;
+
 class PiwikPlugin extends PluginBase {
 	protected $storage = 'DbStorage';
 	static protected $description = 'Adds Piwik tracking codes to LimeSurvey pages.';


### PR DESCRIPTION
LS classes are now namespaced so we need to import the full class path.
(This will break LS2 compatibility however.)